### PR TITLE
Feature/pg migrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 mastodon.s9pk
 image.tar
+pg-migrate.tar

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 VERSION := $(shell yq e ".version" manifest.yaml)
+DOCKER_CUR_ENGINE := $(shell docker buildx ls | grep "*" | awk '{print $$1;}')
 
 .DELETE_ON_ERROR:
 
@@ -13,5 +14,9 @@ mastodon.s9pk: manifest.yaml assets/compat/* image.tar instructions.md
 install: mastodon.s9pk
 	embassy-cli package install mastodon.s9pk
 
-image.tar: Dockerfile docker_entrypoint.sh reset_first_user.sh check-federation.sh nginx.conf mastodon
-	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/mastodon/main:$(VERSION) --platform=linux/arm64 -o type=docker,dest=image.tar .
+image.tar: Dockerfile docker_entrypoint.sh reset_first_user.sh check-federation.sh nginx.conf mastodon pg-migrate/*
+	docker buildx use default
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/mastodon/main:$(VERSION) --platform=linux/arm64 .
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --tag start9/mastodon/pg-migrate:$(VERSION) --platform=linux/arm64 -f pg-migrate/Dockerfile .
+	docker buildx use $(DOCKER_CUR_ENGINE)
+	docker save -o image.tar start9/mastodon/main:$(VERSION) start9/mastodon/pg-migrate:$(VERSION)

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -84,6 +84,15 @@ chown -R postgres:postgres /root/persistence/pgdata
 test -f /root/persistence/pgdata/PG_VERSION || sudo -u postgres initdb -D /root/persistence/pgdata
 sudo -u postgres postgres -D /root/persistence/pgdata &
 postgres_child=$!
+if [ -f "/root/persistence/db_dump.sql" ]; then
+  until sudo -u postgres psql postgres < /root/persistence/db_dump.sql
+  do
+    echo 'postgres not ready, retrying in 1 second...'
+    sleep 1
+  done
+  rm /root/persistence/db_dump.sql
+fi
+
 mkdir -p /root/persistence/redis-data
 echo "dir /root/persistence/redis-data" | redis-server - &
 redis_child=$!

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -87,7 +87,7 @@ postgres_child=$!
 if [ -f "/root/persistence/db_dump.sql" ]; then
   until sudo -u postgres psql postgres < /root/persistence/db_dump.sql
   do
-    echo 'postgres not ready, retrying in 1 second...'
+    >&2 echo 'postgres not ready, retrying in 1 second...'
     sleep 1
   done
   rm /root/persistence/db_dump.sql

--- a/docker_entrypoint.sh
+++ b/docker_entrypoint.sh
@@ -84,7 +84,7 @@ chown -R postgres:postgres /root/persistence/pgdata
 test -f /root/persistence/pgdata/PG_VERSION || sudo -u postgres initdb -D /root/persistence/pgdata
 sudo -u postgres postgres -D /root/persistence/pgdata &
 postgres_child=$!
-if [ -f "/root/persistence/db_dump.sql" ]; then
+if [ -s "/root/persistence/db_dump.sql" ]; then
   until sudo -u postgres psql postgres < /root/persistence/db_dump.sql
   do
     >&2 echo 'postgres not ready, retrying in 1 second...'

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -168,6 +168,6 @@ migrations:
       type: docker
       image: main
       entrypoint: sh
-      args: ["-c", 'json=''{"configured": true }'' && echo "$json"']
+      args: []
       io-format: json
       inject: true

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -151,3 +151,23 @@ actions:
       args: ["reset_first_user.sh"]
       io-format: json
       inject: true
+migrations:
+  from:
+    "<3.4.1":
+      type: docker
+      image: pg-migrate
+      system: false
+      entrypoint: "docker_entrypoint.sh"
+      args: []
+      mounts:
+        main: /root/persistence
+      io-format: json
+      inject: false
+  to:
+    "<3.4.1":
+      type: docker
+      image: main
+      entrypoint: sh
+      args: ["-c", 'json=''{"configured": true }'' && echo "$json"']
+      io-format: json
+      inject: true

--- a/pg-migrate/Dockerfile
+++ b/pg-migrate/Dockerfile
@@ -1,0 +1,21 @@
+# FROM arm32v7/postgres:12-alpine
+FROM arm32v7/ruby:2.6-alpine3.12
+
+# 70 is the standard uid/gid for "postgres" in Alpine
+# https://git.alpinelinux.org/aports/tree/main/postgresql/postgresql.pre-install?h=3.12-stable
+RUN set -eux; \
+    addgroup -g 70 -S postgres; \
+    adduser -u 70 -S -D -G postgres -H -h /var/lib/postgresql -s /bin/sh postgres; \
+    mkdir -p /var/lib/postgresql; \
+    chown -R postgres:postgres /var/lib/postgresql
+
+RUN apk add postgresql sudo
+
+RUN mkdir -p /run/postgresql \
+    && chmod 777 /run \
+    && chown postgres:postgres /run/postgresql
+
+ADD ./pg-migrate/docker_entrypoint.sh /usr/local/bin/docker_entrypoint.sh
+RUN chmod a+x /usr/local/bin/docker_entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker_entrypoint.sh"]

--- a/pg-migrate/docker_entrypoint.sh
+++ b/pg-migrate/docker_entrypoint.sh
@@ -29,5 +29,6 @@ if [ -s /root/persistence/db_dump.sql ]; then
   echo '{"configured": true }'
   exit 0
 else
+  echo "FATAL: Migration failed." >&2
   exit 1
 fi

--- a/pg-migrate/docker_entrypoint.sh
+++ b/pg-migrate/docker_entrypoint.sh
@@ -2,6 +2,11 @@
 
 set -ea
 
+if [ -s /root/persistence/db_dump.sql ]; then
+  echo '{"configured": true }'
+  exit 0
+fi
+
 DB_HOST=localhost
 DB_USER=postgres
 DB_NAME=postgres
@@ -16,10 +21,15 @@ sudo -u postgres postgres -D /root/persistence/pgdata &
 
 until sudo -u postgres pg_dump > /root/persistence/db_dump.sql
 do
-  echo 'postgres not ready, retrying in 1 second...'
+  # echo 'postgres not ready, retrying in 1 second...'
   sleep 1
 done
 
 if [ -s /root/persistence/db_dump.sql ]; then
   rm -rf /root/persistence/pgdata
+  echo '{"configured": true }'
+  exit 0
+else
+  echo '{"configured": false }' >&2
+  exit 1
 fi

--- a/pg-migrate/docker_entrypoint.sh
+++ b/pg-migrate/docker_entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -ea
+
+DB_HOST=localhost
+DB_USER=postgres
+DB_NAME=postgres
+DB_PORT=5432
+
+chmod 777 /root
+chmod 777 /root/persistence
+mkdir -p /root/persistence/pgdata
+chown -R postgres:postgres /root/persistence/pgdata
+test -f /root/persistence/pgdata/PG_VERSION || exit 1
+sudo -u postgres postgres -D /root/persistence/pgdata &
+
+until sudo -u postgres pg_dump > /root/persistence/db_dump.sql
+do
+  echo 'postgres not ready, retrying in 1 second...'
+  sleep 1
+done
+
+if [ -s /root/persistence/db_dump.sql ]; then
+  rm -rf /root/persistence/pgdata
+fi

--- a/pg-migrate/docker_entrypoint.sh
+++ b/pg-migrate/docker_entrypoint.sh
@@ -21,7 +21,6 @@ sudo -u postgres postgres -D /root/persistence/pgdata &
 
 until sudo -u postgres pg_dump > /root/persistence/db_dump.sql
 do
-  # echo 'postgres not ready, retrying in 1 second...'
   sleep 1
 done
 
@@ -30,6 +29,5 @@ if [ -s /root/persistence/db_dump.sql ]; then
   echo '{"configured": true }'
   exit 0
 else
-  echo '{"configured": false }' >&2
   exit 1
 fi


### PR DESCRIPTION
Adds `pg-migrate` docker image to dump 32-bit postgres db to `db_dump.sql` and delete old db.
Adds code to `main` image to detect `db-dump.sql` and import into newly generated db (since old db was previously deleted)

Unfortunately the resulting s9pk is over 1GB in size, since I couldn't figure out a way to save multiple docker images in the same tar file while also using compression.

Went with Alpine 3.13 since that's what we were already using on the `0.3.0` branch (02x mastodon used 3.12). This results in postgres 13 and nginx 1.18. Updating to Alpine 3.15 resulted in 404s from nginx, possibly because 3.15 comes with nginx 1.20 rather than 1.18.